### PR TITLE
Relicense under Apache-2.0/MIT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
   "Corey Richardson <corey@octayn.net>",
   "Ivan Ukhov <ivan.ukhov@gmail.com>",
 ]
-license = "BSL-1.0"
+license = "Apache-2.0/MIT"
 repository = "https://github.com/cmr/openblas-provider"
 homepage = "https://github.com/cmr/openblas-provider"
 description = """

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,49 @@
+# License
+
+The project is dual licensed under the terms of the Apache License, Version 2.0,
+and the MIT License. You may obtain copies of the two licenses at
+
+* https://www.apache.org/licenses/LICENSE-2.0 and
+* https://opensource.org/licenses/MIT, respectively.
+
+The following two notices apply to every file of the project.
+
+## The Apache License
+
+```
+Copyright 2015–1016 The OpenBLAS Provider Developers
+
+Licensed under the Apache License, Version 2.0 (the “License”); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+```
+
+## The MIT License
+
+```
+Copyright 2015–2016 The OpenBLAS Provider Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ This package provides only an implementation of BLAS and LAPACK. Bindings are
 available in [blas-sys][4] and [lapack-sys][5], and wrappers are available in
 [blas][6] and [lapack][7].
 
-## Contributing
+## Contribution
 
-1. Fork the project.
-2. Implement your idea.
-3. Open a pull request.
+Contribution is very much appreciated. Fork the project, commit your changes,
+and open a pull request! Note that any contribution will be licensed according
+to the terms given in [LICENSE.md](LICENSE.md).
 
 [1]: https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms
 [2]: https://en.wikipedia.org/wiki/LAPACK


### PR DESCRIPTION
Hi @cmr,

I’m planning to relicense all BLAS-/LAPACK-related crates under Apache-2.0/MIT, as you suggested. Probably it’s rather futile for bindings and wrappers, but I’d like to do it anyway for consistency. Do you mind if I apply these changes to openblas-provider, netlib-provider, and the rest? Thanks!

Regards,
Ivan